### PR TITLE
fix: Remove original author from `CODEOWNERS` to prevent revew requests.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,5 @@
-* @justinsgithub
+* @DrKJeff16
+/lua/types/config.lua @DrKJeff16
 /lua/types/wezterm/serde.lua @DrKJeff16
 /lua/types/wezterm/plugin.lua @DrKJeff16
 /lua/types/wezterm/url.lua @DrKJeff16


### PR DESCRIPTION
## Changes

 - [fix: Remove original author from `CODEOWNERS` to prevent revew requests.](https://github.com/DrKJeff16/wezterm-types/commit/4221ed82026e51b312bf74243fb3ff97ba25cde6)