### PR TITLE
Remove maintainer from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,6 @@ proper type checking and autocompletion for WezTerm configuration options.
 
 - [@DrKJeff16](https://github.com/DrKJeff16) - **Maintainer, _(current owner)_**
 - [@justinsgithub](https://github.com/justinsgithub) - **The Author _(not active currently)_**
-- [@craigmac](https://github.com/craigmac) - **Maintainer**
 - [@gonstoll](https://github.com/gonstoll) - **Maintainer**
 
 ### Contributors


### PR DESCRIPTION
I no longer use WezTerm and I'm not longer interesting in maintaining this repository.