### PR TITLE
Add SemanticZone for SelectTextAtMouseCursor

### DIFF
--- a/lua/wezterm/types/enum/key-assignment.lua
+++ b/lua/wezterm/types/enum/key-assignment.lua
@@ -490,7 +490,7 @@ local ActionFunc = {}
 ---@return Action
 function ActionFunc.Nop() end
 
----@param s "Line"|"Word"|"Cell"|"Block"
+---@param s "Line"|"Word"|"Cell"|"Block"|"SemanticZone"
 ---@return Action
 function ActionFunc.SelectTextAtMouseCursor(s) end
 


### PR DESCRIPTION
# Add SemanticZone for SelectTextAtMouseCursor

## Changes

- Added `SemanticZone` to `SelectTextAtMouseCursor` parameter enum

## Description (Optional)

SemanticZone was added to the string enum for the parameter.
See https://wezterm.org/config/lua/keyassignment/SelectTextAtMouseCursor.html for explanation.