### PR TITLE
Fixed typo in config.lua

### DIFF
--- a/lua/wezterm/types/config.lua
+++ b/lua/wezterm/types/config.lua
@@ -166,7 +166,7 @@
 ---[`height`](lua://BackgroundLayer.height),
 ---but applied to the x-direction.
 ---
----@field widtht? "Cover"|"Contain"|number|string
+---@field width? "Cover"|"Contain"|number|string
 
 ---@alias AllFontAttributes
 ---|Fonts


### PR DESCRIPTION
# Fixed typo in config.lua

## Changes

- Fixed typo in `config.lua`: `widtht` to `width`

## Description (Optional)

When auto-completing, I had an error in my config syntax. The fix was to replace `widtht` to `width`, used in the layer table for defining a background.

## Screenshots Or Code Snippets (Optional)

If relevant, include any screenshots/code snippets you could provide, as
additional context.
