### PR TITLE
fix: type definitions for `MuxTab` pane info and `PaneInformation`

### DIFF
--- a/lua/wezterm/types/objects/mux-tab.lua
+++ b/lua/wezterm/types/objects/mux-tab.lua
@@ -7,6 +7,9 @@
 ---@field pixel_height integer
 ---@field dpi number
 
+---Mirrors `MuxPaneInfo` in wezterm upstream:
+---https://github.com/wezterm/wezterm/blob/main/lua-api-crates/mux/src/lib.rs
+---
 ---@class MuxTab.PaneInfo
 ---The topological pane index.
 ---
@@ -20,23 +23,23 @@
 ---The offset from the top left corner of the containing tab
 ---to the top left corner of this pane, in cells.
 ---
----@field left number
+---@field left integer
 ---The offset from the top left corner of the containing tab
 ---to the top left corner of this pane, in cells.
 ---
----@field top number
+---@field top integer
 ---The width of the pane in cells.
 ---
----@field width number
+---@field width integer
 ---The height of the pane in cells.
 ---
----@field height number
+---@field height integer
 ---The width of the pane in pixels.
 ---
----@field pixel_width number
+---@field pixel_width integer
 ---The height of the pane in pixels.
 ---
----@field pixel_height number
+---@field pixel_height integer
 ---A `Pane` object.
 ---
 ---@field pane Pane

--- a/lua/wezterm/types/objects/pane-information.lua
+++ b/lua/wezterm/types/objects/pane-information.lua
@@ -1,5 +1,8 @@
 ---@meta
 
+---Mirrors `Progress` in wezterm upstream:
+---https://github.com/wezterm/wezterm/blob/main/term/src/terminal.rs
+---
 ---@alias PaneProgress
 ---|"None"
 ---|"Indeterminate"
@@ -13,10 +16,13 @@
 ---intended for use in synchronous, fast, event callbacks
 ---that format GUI elements such as the window and tab title bars.
 ---
+---Mirrors `PaneInformation` in wezterm upstream:
+---https://github.com/wezterm/wezterm/blob/main/wezterm-gui/src/termwindow/mod.rs
+---
 ---@class PaneInformation
 ---The height of the pane in cells.
 ---
----@field height number
+---@field height integer
 ---Is `true` if the pane is the active pane within its containing tab.
 ---
 ---@field is_active boolean
@@ -25,10 +31,10 @@
 ---@field is_zoomed boolean
 ---The cell `x` coordinate of the left edge of the pane.
 ---
----@field left number
+---@field left integer
 ---The height of the pane in pixels.
 ---
----@field pixel_height number
+---@field pixel_height integer
 ---The pane ID.
 ---
 ---@field pane_id integer
@@ -37,7 +43,7 @@
 ---@field pane_index integer
 ---The width of the pane in pixels.
 ---
----@field pixel_width number
+---@field pixel_width integer
 ---The progress state,
 ---per [`Pane:get_progress()`](lua://Pane.get_progress)
 ---at the time the pane information was captured.
@@ -50,7 +56,7 @@
 ---@field title string
 ---The cell `y` coordinate of the top edge of the pane.
 ---
----@field top number
+---@field top integer
 ---The user variables defined for the pane,
 ---per [`Pane:get_user_vars()`](lua://Pane.get_user_vars)
 ---at the time the pane information was captured.
@@ -58,7 +64,7 @@
 ---@field user_vars table<string, string>
 ---The width of the pane in cells.
 ---
----@field width number
+---@field width integer
 ---The path to the executable image, per `Pane:get_foreground_process_name()`.
 ---
 ---If the path is unavailable then this field will be an empty string.

--- a/lua/wezterm/types/objects/pane.lua
+++ b/lua/wezterm/types/objects/pane.lua
@@ -363,6 +363,9 @@ function M:get_metadata() end
 ---will be `"None"` to indicate that
 ---no progress has been reported.
 ---
+---Mirrors the `get_progress` Lua binding in wezterm upstream:
+---https://github.com/wezterm/wezterm/blob/main/lua-api-crates/mux/src/pane.rs
+---
 ---@return PaneProgress progress
 function M:get_progress() end
 

--- a/lua/wezterm/types/wezterm.lua
+++ b/lua/wezterm/types/wezterm.lua
@@ -1426,7 +1426,6 @@ function Wezterm.on(event, callback) end
 ---it doesn't make sense to define multiple instances of the event
 ---with multiple `wezterm.on("format-window-title", ...)` calls.
 ---
---- ---
 ---The `"format-window-title"` event is emitted when the text for the window title
 ---needs to be recomputed.
 ---
@@ -1440,6 +1439,9 @@ function Wezterm.on(event, callback) end
 ---
 ---For more information, see:
 --- - [`wezterm.run_child_process()`](lua://Wezterm.run_child_process)
+---
+---Mirrors the `format-window-title` callback arguments in wezterm upstream:
+---https://github.com/wezterm/wezterm/blob/main/wezterm-gui/src/termwindow/mod.rs
 ---
 ---@param event "format-window-title"
 ---@param callback fun(tab: TabInformation, pane: PaneInformation, tabs: TabInformation[], panes: PaneInformation[], config: Config): string


### PR DESCRIPTION
## Changes

- Added `MuxTab.PaneInfo` and changed `MuxTab:panes_with_info()` to return `MuxTab.PaneInfo[]`.
- Aligned `PaneInformation` with upstream fields by adding `foreground_process_name`, `current_working_dir`, `has_unseen_output`, `domain_name`, and `tty_name`.
- Added `PaneProgress` with return type options and updated `PaneInformation.progress` and `Pane:get_progress()` to use it.
- Changed `wezterm.on("format-window-title", ...)` callback typing to use `TabInformation`/`PaneInformation` payloads.

---

## Source(s)

- `MuxTab:panes_with_info()` structure and `pane` field:
  - https://github.com/wezterm/wezterm/blob/05343b387085842b434d267f91b6b0ec157e4331/lua-api-crates/mux/src/tab.rs
  - https://github.com/wezterm/wezterm/blob/05343b387085842b434d267f91b6b0ec157e4331/docs/config/lua/MuxTab/panes_with_info.md
- `PaneInformation` field accessors:
  - https://github.com/wezterm/wezterm/blob/05343b387085842b434d267f91b6b0ec157e4331/wezterm-gui/src/termwindow/mod.rs
- `format-window-title` callback parameter shapes:
  - https://github.com/wezterm/wezterm/blob/05343b387085842b434d267f91b6b0ec157e4331/docs/config/lua/window-events/format-window-title.md

---

## Description (Optional)

see above

---

## Screenshots Or Code Snippets (Optional)

not applicable

<!-- vim: set ts=2 sts=2 sw=2 et ai si sta: -->
