### PR TITLE
feat(plugins.bar): add new zoom and ssh modules, new tab theming options

### DIFF
--- a/lua/wezterm/types/plugins/bar.lua
+++ b/lua/wezterm/types/plugins/bar.lua
@@ -14,8 +14,12 @@ local positions = {
 ---@field space? integer
 
 ---@class BarWeztermOpts.Tabs
----@field active_tab_fg? integer
----@field inactive_tab_fg? integer
+---@field active_tab_bg? number|string
+---@field active_tab_fg? number|string
+---@field inactive_tab_bg? number|string
+---@field inactive_tab_fg? number|string
+---@field new_tab_bg? number|string
+---@field new_tab_fg? number|string
 
 ---@class BarWeztermOpts.Module
 ---@field color? integer
@@ -35,10 +39,12 @@ local positions = {
 ---@field hostname? BarWeztermOpts.Module
 ---@field leader? BarWeztermOpts.Module
 ---@field pane? BarWeztermOpts.Module
+---@field ssh? BarWeztermOpts.Module
 ---@field spotify? BarWeztermOpts.Spotify
 ---@field tabs? BarWeztermOpts.Tabs
 ---@field username? BarWeztermOpts.Module
 ---@field workspace? BarWeztermOpts.Module
+---@field zoom? BarWeztermOpts.Module
 
 ---@class BarWeztermOpts.Padding.Tabs
 ---@field left? integer


### PR DESCRIPTION
## Changes

- add new zoom and ssh modules
- make `BarWeztermOpts.Tabs` accept numbers and strings and add new background entries

---

## Source(s)

- SSH was added here https://github.com/adriankarlen/bar.wezterm/commit/af6642a004942d6b58b777d002cb7ee82ca94872
- Zoom was added here https://github.com/adriankarlen/bar.wezterm/commit/ccdb5ad64a73e2fe96f93a1fc0adb8fe73f5d139 
- New background and new typing here https://github.com/adriankarlen/bar.wezterm/commit/80e61821a673ad63c52a6487fb6ba596788a0139 

---

## Description (Optional)

Already covered above

---

## Screenshots Or Code Snippets (Optional)

N/A

<!-- vim: set ts=2 sts=2 sw=2 et ai si sta: -->
