### PR TITLE
fix(plugin-maintenance): prevent duplicate maintenance labels

### DIFF
--- a/.github/workflows/plugin-maintenance-accept.yml
+++ b/.github/workflows/plugin-maintenance-accept.yml
@@ -185,6 +185,7 @@ jobs:
             commit -m "$COMMIT_MESSAGE"
           git push origin "HEAD:$BRANCH"
       - name: Open acceptance PR
+        id: open
         if: steps.update.outputs.changed == 'true' && steps.pr.outputs.existing_pr == ''
         env:
           BRANCH: ${{ steps.pr.outputs.branch }}
@@ -234,7 +235,26 @@ jobs:
             --base "${{ github.event.repository.default_branch }}" \
             --head "$BRANCH" \
             --title "$PR_TITLE" \
-            --label plugin-maintenance \
             --body-file "$body")
 
+          echo "pr_url=$pr_url" >> "$GITHUB_OUTPUT"
           echo "Created acceptance PR: $pr_url" >> "$GITHUB_STEP_SUMMARY"
+      - name: Ensure acceptance PR label
+        if: steps.update.outputs.changed == 'true'
+        env:
+          EXISTING_PR: ${{ steps.pr.outputs.existing_pr }}
+          CREATED_PR: ${{ steps.open.outputs.pr_url }}
+        run: |
+          set -euo pipefail
+          pr_url=${EXISTING_PR:-$CREATED_PR}
+          pr_number=${pr_url##*/}
+          [[ "$pr_url" == */pull/"$pr_number" && "$pr_number" =~ ^[0-9]+$ ]] \
+            || { echo "Invalid acceptance PR URL: $pr_url" >&2; exit 1; }
+
+          has_label=$(gh api "repos/$GITHUB_REPOSITORY/issues/$pr_number" \
+            --jq '[.labels[].name] | index("plugin-maintenance") != null')
+          if [[ "$has_label" != "true" ]]; then
+            gh api --method POST \
+              "repos/$GITHUB_REPOSITORY/issues/$pr_number/labels" \
+              -f 'labels[]=plugin-maintenance' >/dev/null
+          fi

--- a/.github/workflows/plugin-maintenance.yml
+++ b/.github/workflows/plugin-maintenance.yml
@@ -119,6 +119,9 @@ jobs:
         uses: actions/deploy-pages@v5
   update-maintenance-digest:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    concurrency:
+      group: plugin-maintenance-digest
+      cancel-in-progress: false
     needs:
       - build-report
       - deploy-pages
@@ -204,16 +207,35 @@ jobs:
           gh label create plugin-maintenance --repo "$GITHUB_REPOSITORY" \
             --color D4A72C --description "Automated plugin upstream review" --force
 
-          issue_json=$(gh issue list --repo "$GITHUB_REPOSITORY" \
-            --state all --label plugin-maintenance --limit 100 --json number,title,state \
-            --jq '[.[] | select(.title == env.DIGEST_TITLE)][0] // {}')
+          issue_json=$(
+            gh api --paginate \
+              "repos/$GITHUB_REPOSITORY/issues?state=all&per_page=100" |
+              jq -sc --arg title "$DIGEST_TITLE" '
+                add
+                | map(select(
+                    (has("pull_request") | not)
+                    and .title == $title
+                    and ((.body // "") | startswith("<!-- plugin-maintenance-digest -->"))
+                  ))
+                | if length > 1 then
+                    error("Multiple plugin maintenance digest issues found")
+                  elif length == 1 then
+                    {number: .[0].number, state: (.[0].state | ascii_upcase)}
+                  else
+                    {}
+                  end
+              '
+          )
           issue_number=$(jq -r '.number // empty' <<< "$issue_json")
           issue_state=$(jq -r '.state // empty' <<< "$issue_json")
 
           if (( outstanding > 0 )); then
             if [[ -z "$issue_number" ]]; then
-              gh issue create --repo "$GITHUB_REPOSITORY" \
-                --title "$DIGEST_TITLE" --label plugin-maintenance --body-file "$body"
+              issue_url=$(gh issue create --repo "$GITHUB_REPOSITORY" \
+                --title "$DIGEST_TITLE" --body-file "$body")
+              issue_number=${issue_url##*/}
+              [[ "$issue_url" == */issues/"$issue_number" && "$issue_number" =~ ^[0-9]+$ ]] \
+                || { echo "Invalid maintenance digest issue URL: $issue_url" >&2; exit 1; }
             else
               gh issue edit "$issue_number" --repo "$GITHUB_REPOSITORY" --body-file "$body"
               if [[ "$issue_state" == "CLOSED" ]]; then
@@ -228,6 +250,16 @@ jobs:
               echo "No upstream changes require review as of \`$(jq -r '.checked_at' "$report")\`."
             } > "$body"
             gh issue edit "$issue_number" --repo "$GITHUB_REPOSITORY" --body-file "$body"
+          fi
+
+          if [[ -n "$issue_number" ]]; then
+            has_label=$(gh api "repos/$GITHUB_REPOSITORY/issues/$issue_number" \
+              --jq '[.labels[].name] | index("plugin-maintenance") != null')
+            if [[ "$has_label" != "true" ]]; then
+              gh api --method POST \
+                "repos/$GITHUB_REPOSITORY/issues/$issue_number/labels" \
+                -f 'labels[]=plugin-maintenance' >/dev/null
+            fi
           fi
   report-health:
     if: always() && needs.build-report.result == 'success'

--- a/doc/wezterm-types.txt
+++ b/doc/wezterm-types.txt
@@ -1,4 +1,4 @@
-*wezterm-types.txt*         For NVIM >=v0.7.0        Last change: 2026 July 24
+*wezterm-types.txt*         For NVIM >=v0.7.0        Last change: 2026 July 25
 
 ==============================================================================
 1. wezterm-types                                 *wezterm-types-wezterm-types*


### PR DESCRIPTION
## Changes

- Prevent duplicate maintenance labels in some workflows

---

## Source(s)

N/A

---

## Description (Optional)

- Separated PR/issue creation from labeling, adding labels only when absent to prevent duplicate events.
- Added serialized digest updates and reliable marker-based issue discovery for safe retries.

---

## Screenshots Or Code Snippets (Optional)

<img width="1191" height="367" alt="image" src="https://github.com/user-attachments/assets/30f9fcc0-c8ce-4a06-abfa-6fe1f8b2d4eb" />

<!-- vim: set ts=2 sts=2 sw=2 et ai si sta: -->
